### PR TITLE
fix memory leak

### DIFF
--- a/PokemonGo.RocketAPI/Helpers/Crypt.cs
+++ b/PokemonGo.RocketAPI/Helpers/Crypt.cs
@@ -63,6 +63,12 @@ namespace PokemonGo.RocketAPI.Helpers
 
             var output = new byte[outputLength];
             Marshal.Copy(ptrOutput, output, 0, outputLength);
+
+            //Free allocated memory
+            Marshal.FreeHGlobal(ptr);
+            Marshal.FreeHGlobal(ptrOutput);
+            Marshal.FreeHGlobal(iv_ptr);
+
             return output;
         }
     }


### PR DESCRIPTION
The memory allocated by Marshal.AllocHGlobal, it needs to be freed by
Marshal.FreeHGlobal.